### PR TITLE
ダイアログコンポーネントを新規に作成

### DIFF
--- a/src/components/molecules/Dialog/Dialog.stories.tsx
+++ b/src/components/molecules/Dialog/Dialog.stories.tsx
@@ -1,0 +1,48 @@
+import type { StoryObj, Meta } from '@storybook/react'
+import { within, fireEvent, userEvent } from '@storybook/testing-library'
+import { useDialog } from './hook/useDialog'
+import { Dialog } from '.'
+import { Button } from '@/components/atoms/Button'
+
+const meta: Meta<typeof Dialog> = {
+  title: 'Molecules/Dialog',
+  args: {
+    title: 'Dialog title',
+    children:
+      'サンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプル',
+  },
+}
+
+export default meta
+
+export const DialogTemplate: StoryObj<typeof Dialog> = {
+  render: function Render(props) {
+    const { open, Dialog } = useDialog()
+
+    return (
+      <div>
+        <h3>Click button!</h3>
+        <Button onClick={open}>Show Dialog</Button>
+        <Dialog {...props} />
+      </div>
+    )
+  },
+}
+
+export const LongContentWithScroll: StoryObj<typeof Dialog> = {
+  ...DialogTemplate,
+  args: {
+    children:
+      'サンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプルサンプル最終行テキスト',
+  },
+  // お試し
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const btn = canvas.getByRole<HTMLButtonElement>('button', {
+      name: /Show Dialog/i,
+    })
+    await userEvent.click(btn)
+    const content = canvas.getByTestId('content')
+    fireEvent.scroll(content, { target: { scrollTop: content.scrollHeight } })
+  },
+}

--- a/src/components/molecules/Dialog/Dialog.test.tsx
+++ b/src/components/molecules/Dialog/Dialog.test.tsx
@@ -1,0 +1,97 @@
+import { composeStories } from '@storybook/testing-react'
+import { render, screen, cleanup } from '@testing-library/react'
+import { act } from '@testing-library/react-hooks'
+import userEvent from '@testing-library/user-event'
+import * as stories from './Dialog.stories'
+
+const { DialogTemplate } = composeStories(stories)
+const DEFAULT_TITLE = 'Dialog title'
+
+/**
+ * チェック項目memo
+ * 1. 初期表示では非表示になっているか
+ * 2. 開くボタンをクリックしたら表示されるか
+ * 3. 閉じるボタンをクリックしたら非表示になるか
+ * 4. ダイアログの外側をクリックしたら非表示になるか
+ * 5. ダイアログの内側をクリックしたら非表示にならないか
+ * 6. 渡したpropsに応じて表示が正しく反映されるか
+ * 7. 閉じるボタンにfocusが当たった状態でEnterキーを押下したら非表示になるか
+ */
+
+describe('Dialog Component', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  const openDialog = async () => {
+    const btn = screen.getByRole<HTMLButtonElement>('button', {
+      name: /Show Dialog/i,
+    })
+    await act(async () => await userEvent.click(btn))
+  }
+
+  it('not displayed at initial rendering', () => {
+    render(<DialogTemplate />)
+    const text = screen.queryByText(DEFAULT_TITLE)
+    expect(text).not.toBeInTheDocument()
+  })
+
+  it('should be displayed when the open button is clicked', async () => {
+    render(<DialogTemplate />)
+    await openDialog()
+    expect(await screen.findByText(DEFAULT_TITLE)).toBeInTheDocument()
+  })
+
+  it('should be hidden when the close button is clicked', async () => {
+    render(<DialogTemplate />)
+    await openDialog()
+    const closeBtn = screen.getByRole<HTMLButtonElement>('button', {
+      name: /close/i,
+    })
+    await act(async () => await userEvent.click(closeBtn))
+    expect(screen.queryByText(DEFAULT_TITLE)).not.toBeInTheDocument()
+  })
+
+  it('should be hidden when clicking outside of dialog', async () => {
+    render(<DialogTemplate />)
+    await openDialog()
+    const overlay = screen.getByTestId('overlay')
+    await act(async () => await userEvent.click(overlay))
+    expect(screen.queryByText(DEFAULT_TITLE)).not.toBeInTheDocument()
+  })
+
+  it('should not hide when clicking inside the dialog', async () => {
+    render(<DialogTemplate />)
+    await openDialog()
+    const dialog = screen.getByTestId('content')
+    await act(async () => await userEvent.click(dialog))
+    expect(await screen.findByText(DEFAULT_TITLE)).toBeInTheDocument()
+  })
+
+  it('should render with custom props', async () => {
+    const props = {
+      title: 'Test dialog',
+      children: 'This is a test dialog.',
+    }
+    render(<DialogTemplate {...props} />)
+    await openDialog()
+    const title = screen.getByText(props.title)
+    const content = screen.getByText(props.children)
+    expect(title).toBeInTheDocument()
+    expect(content).toBeInTheDocument()
+  })
+
+  it('should be closed with the enter key after the close button is focused', async () => {
+    render(<DialogTemplate />)
+    await openDialog()
+    const closeBtn = screen.getByRole<HTMLButtonElement>('button', {
+      name: /close/i,
+    })
+    await userEvent.tab() // select first element (open button)
+    await userEvent.tab() // select close button in dialog
+
+    expect(closeBtn).toHaveFocus()
+    await act(async () => await userEvent.type(closeBtn, '{enter}'))
+    expect(screen.queryByText(DEFAULT_TITLE)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/molecules/Dialog/hook/useDialog.test.tsx
+++ b/src/components/molecules/Dialog/hook/useDialog.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook, render, screen } from '@testing-library/react'
+import { act } from '@testing-library/react-hooks'
+import { useDialog, UseDialogReturnType } from './useDialog'
+
+/**
+ * チェック項目memo
+ * 1. isOpenの初期値がfalseになっているか
+ * 2. open発火後にisOpenがtrueに変更されるか
+ * 3. close発火後にisOpenがfalseに変更されるか
+ * 4. isOpenがtrueの時にDialogコンポーネントが表示されるか
+ * 5. isOpenがfalseの時にDialogコンポーネントが表示されるか
+ */
+
+describe('useDialog', () => {
+  let result: { current: UseDialogReturnType }
+
+  beforeEach(() => {
+    result = renderHook(() => useDialog()).result
+  })
+
+  it('should have initial isOpen value of false', () => {
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  it('should set isOpen to true after calling open function', () => {
+    const event = new MouseEvent('click') as unknown as React.MouseEvent<
+      HTMLButtonElement,
+      MouseEvent
+    >
+    act(() => result.current.open(event))
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  it('should set isOpen to false after calling close function', () => {
+    act(() => result.current.close())
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  it('should render Dialog component when isOpen is true', async () => {
+    const event = new MouseEvent('click') as unknown as React.MouseEvent<
+      HTMLButtonElement,
+      MouseEvent
+    >
+    act(() => result.current.open(event))
+
+    render(<result.current.Dialog title="Test Dialog" isOpen={true} />)
+    expect(screen.getByText('Test Dialog')).toBeInTheDocument()
+  })
+
+  it('should render Dialog component when isOpen is false', async () => {
+    render(<result.current.Dialog title="Test Dialog" isOpen={false} />)
+    expect(screen.queryByText('Test Dialog')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/molecules/Dialog/hook/useDialog.tsx
+++ b/src/components/molecules/Dialog/hook/useDialog.tsx
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react'
+import { Dialog as Component, DialogProps } from '@/components/molecules/Dialog'
+
+export type UseDialogReturnType = {
+  isOpen: boolean
+  open: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+  close: () => void
+  Dialog: React.FC<DialogProps>
+}
+
+type ComponentType = Pick<DialogProps, 'title' | 'children'>
+
+export const useDialog = (): UseDialogReturnType => {
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  const open = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      e.stopPropagation()
+      setIsOpen(true)
+    },
+    [],
+  )
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
+  const Dialog: React.FC<ComponentType> = useCallback(
+    (props) => {
+      return <Component {...props} isOpen={isOpen} handleClose={close} />
+    },
+    [close, isOpen],
+  )
+
+  return {
+    isOpen,
+    open,
+    close,
+    Dialog,
+  }
+}

--- a/src/components/molecules/Dialog/index.tsx
+++ b/src/components/molecules/Dialog/index.tsx
@@ -1,0 +1,83 @@
+import type { FC } from 'react'
+import { useEffect, useRef } from 'react'
+import styled from 'styled-components'
+import { Button } from '@/components/atoms/Button'
+
+export type DialogProps = {
+  title?: string
+  children?: React.ReactNode
+  isOpen?: boolean
+  handleClose?: () => void
+}
+
+export const Dialog: FC<DialogProps> = (props) => {
+  const { title = 'Dialog title', children, isOpen, handleClose } = props
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickToCloseDialog = (e: MouseEvent) => {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+        if (handleClose) handleClose()
+      }
+    }
+    document.addEventListener('click', handleClickToCloseDialog)
+    return () => {
+      document.removeEventListener('click', handleClickToCloseDialog)
+    }
+  }, [handleClose])
+
+  return (
+    <>
+      {isOpen ? (
+        <Overlay data-testid="overlay">
+          <Container ref={dialogRef}>
+            <Header>
+              <h3>{title}</h3>
+              <Button onClick={handleClose} color="secondary">
+                Close
+              </Button>
+            </Header>
+            <Content data-testid="content">{children}</Content>
+          </Container>
+        </Overlay>
+      ) : null}
+    </>
+  )
+}
+
+const Container = styled.div`
+  z-index: 5;
+  width: 90%;
+  border: 2px solid #000;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  max-width: 600px;
+`
+
+const Header = styled.div`
+  padding: 0px 20px;
+  border-bottom: 2px solid #000;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #fffbdb;
+`
+
+const Content = styled.div`
+  padding: 10px 20px;
+  background-color: #fff;
+  max-height: 400px;
+  overflow-y: auto;
+  overflow-x: hidden;
+`
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`


### PR DESCRIPTION

- molecules配下にDialogコンポーネント用のファイルを配置
- カスタムフックを使ってダイアログを使用する形で実装

```
## テスト項目

Dialog.test.tsx
* 1. 初期表示では非表示になっているか
 * 2. 開くボタンをクリックしたら表示されるか
 * 3. 閉じるボタンをクリックしたら非表示になるか
 * 4. ダイアログの外側をクリックしたら非表示になるか
 * 5. ダイアログの内側をクリックしたら非表示にならないか
 * 6. 渡したpropsに応じて表示が正しく反映されるか
 * 7. 閉じるボタンにfocusが当たった状態でEnterキーを押下したら非表示になるか

useDialog.test.tsx
 * 1. isOpenの初期値がfalseになっているか
 * 2. open発火後にisOpenがtrueに変更されるか
 * 3. close発火後にisOpenがfalseに変更されるか
 * 4. isOpenがtrueの時にDialogコンポーネントが表示されるか
 * 5. isOpenがfalseの時にDialogコンポーネントが表示されるか
```